### PR TITLE
added missing attributes

### DIFF
--- a/Syntaxes/VHDL.tmLanguage
+++ b/Syntaxes/VHDL.tmLanguage
@@ -1429,7 +1429,7 @@
 			<array>
 				<dict>
 					<key>match</key>
-					<string>'(?i:active|ascending|base|delayed|driving|event|high|image|instance|last|left|leftof|length|low|path|pos|pred|quiet|range|reverse|right|rightof|simple|stable|succ|transaction|val|value)\b</string>
+					<string>'(?i:active|ascending|base|delayed|driving|event|high|image|instance|instance_name|last|last_value|left|leftof|length|low|path|path_name|pos|pred|quiet|range|reverse|reverse_range|right|rightof|simple|simple_name|stable|succ|transaction|val|value)\b</string>
 					<key>name</key>
 					<string>keyword.attributes.vhdl</string>
 				</dict>


### PR DESCRIPTION
After seeing that reverse_range was not highlited, I checked with our reference and added the other attributes that where not in the list yet.
