### PR TITLE
Add /usr/bin to path in VHDL build system

### DIFF
--- a/VHDL.sublime-build
+++ b/VHDL.sublime-build
@@ -1,5 +1,5 @@
 {
     "cmd": ["ghdl", "-a", "$file"],
-    "path": "/usr/local/bin",
+    "path": "/usr/local/bin:/usr/bin",
     "selector": "source.vhd, source.vhdl"
 }


### PR DESCRIPTION
If gcc is not found on the path when ghdl is invoked, it will complain that gcc is not installed and fail.

On OSX, XCode installs gcc into /usr/bin by default.
On Ubuntu 14.04, gcc is installed into /usr/bin by default.